### PR TITLE
Retire vCenter password rotation (VSPHERE_PASSWORD)

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -5,9 +5,8 @@ on:
   push:
     branches:
       - main
-  schedule:
-        - cron:  '0 */8 * * *'
-        
+  # Scheduled rotation retired 2026-07-09: the vcenter varset is now static (no
+  # rotating VSPHERE_PASSWORD to refresh). Applies run on push / manual dispatch only.
 
 env:
   TF_CLOUD_ORGANIZATION: "tfo-apj-demos"

--- a/10 - vcenter_creds.tf
+++ b/10 - vcenter_creds.tf
@@ -3,34 +3,29 @@ module "vcenter_credentials" {
   version = "~> 0.0"
 
   tfc_organization = "tfo-apj-demos"
-  varset_name = "__gcve_vcenter_variables"
-  workspace_tags = [ "vcenter" ]
+  varset_name      = "__gcve_vcenter_variables"
+  workspace_tags   = ["vcenter"]
 
+  # VSPHERE_PASSWORD retired 2026-07-09. Every vSphere workspace now reads the
+  # vm_builder password from Vault at run time via TFC workload-identity dynamic
+  # credentials. The sole exception, vsphere-vault-deploy — which deploys the very
+  # Vault it would otherwise read from (a circular dependency) — uses a dedicated
+  # long-living account set as a workspace-level VSPHERE_PASSWORD.
+  #
+  # This varset now carries only the static, non-rotating server + username, so the
+  # 8-hourly rotation apply is no longer needed (schedule removed from the GitHub
+  # Action). vm_builder's username is static — Vault rotates the password, not the
+  # account name — so it is hardcoded here instead of read from the Vault LDAP mount.
   varset_variables = [
     {
-      name = "VSPHERE_USER"
-      value = "${data.vault_ldap_static_credentials.this.username}@hashicorp.local"
+      name     = "VSPHERE_USER"
+      value    = "vm_builder@hashicorp.local"
       category = "env"
     },
     {
-      name = "VSPHERE_PASSWORD"
-      value = data.vault_ldap_static_credentials.this.password
-      category = "env"
-      sensitive = true
-    },
-    {
-      name = "VSPHERE_SERVER"
-      value = var.vcenter_address
+      name     = "VSPHERE_SERVER"
+      value    = var.vcenter_address
       category = "env"
     }
   ]
-}
-
-/*data "vault_generic_secret" "this" {
-  path = "ldap/creds/vsphere_access"
-}*/
-
-data "vault_ldap_static_credentials" "this" {
-  mount     = "ldap"
-  role_name = "vm_builder"
 }


### PR DESCRIPTION
## What
Retires the rotating `VSPHERE_PASSWORD` from the `__gcve_vcenter_variables` varset and the fragile 8-hourly rotation.

- `10 - vcenter_creds.tf`: drop the `VSPHERE_PASSWORD` var + the Vault LDAP data source; hardcode the static `VSPHERE_USER = vm_builder@hashicorp.local` (only the *password* rotated, never the username). Keeps `VSPHERE_SERVER`.
- `terraform-apply.yaml`: remove the `schedule: cron` trigger (the thing that got auto-disabled after 60 days of repo inactivity and caused estate-wide vCenter auth failures). Applies still run on push / manual dispatch.

## Why it's safe
The varset is attached to **10 workspaces**. **9** were migrated to read `vm_builder` from Vault at run time (workload-identity dynamic creds) and no longer use the `VSPHERE_PASSWORD` env var. The **1** exception — `vsphere-vault-deploy` — now carries its **own** `VSPHERE_PASSWORD` (a dedicated long-living account), because it deploys the very Vault it would otherwise read from (a circular dependency).

## ⚠️ On merge
The push triggers the `tfc-variable-sets` apply, which **drops `VSPHERE_PASSWORD` from the live varset**. Reversible via `git revert` + re-apply (the value is re-derived from Vault). After merge, verify a migrated workspace still authenticates with a plan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Merge updates the live varset and drops a shared vCenter password env var across tagged workspaces; misconfiguration could break vSphere auth until workspaces are confirmed on Vault dynamic creds.
> 
> **Overview**
> **Stops pushing a rotating `VSPHERE_PASSWORD` through the shared `__gcve_vcenter_variables` varset** and removes the GitHub Action cron that re-applied it every 8 hours.
> 
> In `10 - vcenter_creds.tf`, the varset now only sets static **`VSPHERE_USER`** (`vm_builder@hashicorp.local`) and **`VSPHERE_SERVER`**. The sensitive password env var and the **`vault_ldap_static_credentials`** lookup are gone; downstream vSphere workspaces are expected to pull `vm_builder` credentials from Vault at run time (except **`vsphere-vault-deploy`**, which keeps its own workspace-level password).
> 
> The **`terraform-apply`** workflow still runs on **push to `main`** and **manual dispatch** only—no scheduled applies for rotation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6f8407c10051939bd38ecfe7cc5cee8a7779229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->