### PR TITLE
[HOLD] Retire vCenter password rotation — trim varset to VSPHERE_SERVER

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -5,9 +5,9 @@ on:
   push:
     branches:
       - main
-  schedule:
-        - cron:  '0 */8 * * *'
-        
+  # Scheduled rotation retired 2026-07-09: __gcve_vcenter_variables is now static
+  # (no rotating VSPHERE_PASSWORD to refresh). Applies run on push / manual dispatch.
+
 
 env:
   TF_CLOUD_ORGANIZATION: "tfo-apj-demos"

--- a/10 - vcenter_creds.tf
+++ b/10 - vcenter_creds.tf
@@ -3,34 +3,30 @@ module "vcenter_credentials" {
   version = "~> 0.0"
 
   tfc_organization = "tfo-apj-demos"
-  varset_name = "__gcve_vcenter_variables"
-  workspace_tags = [ "vcenter" ]
+  varset_name      = "__gcve_vcenter_variables"
+  workspace_tags   = ["vcenter"]
 
+  # VSPHERE_USER and VSPHERE_PASSWORD retired 2026-07-09. Every vSphere workspace
+  # now reads the vm_builder vCenter credential from Vault at run time via TFC
+  # workload-identity dynamic credentials — the provider "vsphere" block sets both
+  # user and password from data.vault_ldap_static_credentials.vm_builder, so the
+  # workspaces no longer consume VSPHERE_USER/VSPHERE_PASSWORD from this varset.
+  #
+  # The sole exception, vsphere-vault-deploy — which deploys the very Vault it would
+  # otherwise read from (a circular dependency) — uses a dedicated long-living
+  # account set as workspace-level VSPHERE_USER/VSPHERE_PASSWORD that override this
+  # varset. (vsphere-k8s-minikube is intentionally left un-migrated; give it its own
+  # standalone VSPHERE_* vars before this change is applied, or it will lose vCenter
+  # auth on the next run.)
+  #
+  # This varset now carries only the static, non-rotating server address, so the
+  # 8-hourly rotation apply is no longer needed (schedule removed from the GitHub
+  # Action) and the Vault LDAP data source that fed the rotating password is gone.
   varset_variables = [
     {
-      name = "VSPHERE_USER"
-      value = "${data.vault_ldap_static_credentials.this.username}@hashicorp.local"
-      category = "env"
-    },
-    {
-      name = "VSPHERE_PASSWORD"
-      value = data.vault_ldap_static_credentials.this.password
-      category = "env"
-      sensitive = true
-    },
-    {
-      name = "VSPHERE_SERVER"
-      value = var.vcenter_address
+      name     = "VSPHERE_SERVER"
+      value    = var.vcenter_address
       category = "env"
     }
   ]
-}
-
-/*data "vault_generic_secret" "this" {
-  path = "ldap/creds/vsphere_access"
-}*/
-
-data "vault_ldap_static_credentials" "this" {
-  mount     = "ldap"
-  role_name = "vm_builder"
 }


### PR DESCRIPTION
**Draft / hold — do NOT merge until the two consumers below are handled.**

Redo of the reverted PR #2, now that all vSphere VM workspaces read `vm_builder` from Vault at run time (provider block sets user **and** password from `data.vault_ldap_static_credentials.vm_builder`). Verified env-var-free via wrong-`VSPHERE_PASSWORD` plan tests: pool1, pool2, vpn-vm, openshift-deploy, better-together-dev, rds, windows-dc.

**Change:** trim `__gcve_vcenter_variables` to only `VSPHERE_SERVER`; drop `VSPHERE_USER` **and** `VSPHERE_PASSWORD` (both now Vault-sourced in-provider); remove the `vault_ldap_static_credentials` data source and the 8-hourly `schedule: cron` from the apply workflow.

**Blockers before apply:**
1. `better-together-vm-lifecycle-prod` — its deployed config is a stale 2026-05-27 CLI upload still using the env var; apply current `main` first (plan = no changes, safe).
2. `vsphere-k8s-minikube` — left un-migrated and relies on this varset's `VSPHERE_PASSWORD`; give it standalone `VSPHERE_*` vars or migrate it first.

`vsphere-vault-deploy` is unaffected (own dedicated account; only needs `VSPHERE_SERVER`, kept).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how vCenter authentication is supplied platform-wide; unmigrated workspaces (notably vsphere-k8s-minikube) can lose vCenter access on the next apply.
> 
> **Overview**
> Stops pushing rotating vCenter credentials through Terraform Cloud and removes the automation that kept them fresh.
> 
> The **`__gcve_vcenter_variables`** varset now publishes only **`VSPHERE_SERVER`**; **`VSPHERE_USER`** and **`VSPHERE_PASSWORD`** are dropped from `vcenter_creds.tf`, along with the **`vault_ldap_static_credentials`** data source that supplied them. Comments document that tagged vSphere workspaces are expected to get user/password from Vault at run time via provider dynamic credentials, with exceptions for **`vsphere-vault-deploy`** (workspace-level creds) and **`vsphere-k8s-minikube`** (still depends on varset creds unless migrated first).
> 
> The **Terraform Apply** GitHub workflow no longer runs on an **8-hour cron**—applies are limited to **push to `main`** and **manual dispatch**, since the varset is static.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7835b7d394a5f918fa76f9a7c08ec454afa57651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->